### PR TITLE
No longer shallow-cloning req into a new object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const methodFn = method => (path, handler) => {
     const { params, query } = getParamsAndQuery(path, req.url)
 
     if (params && req.method === method) {
-      return handler(Object.assign({}, req, { params, query }), res)
+      return handler(Object.assign(req, { params, query }), res)
     }
   }
 }


### PR DESCRIPTION
I tried doing something along the lines of:

```
const micro = require('micro')
const { json } = micro
const { router, post } = require('microrouter')

const poster = await (req) => json(req)

const server = micro(router(
  post('/:hash', poster)
))
```

But I got:

```
TypeError: stream.on is not a function
    at readStream (node_modules/raw-body/index.js:228:10)
    at executor (node_modules/raw-body/index.js:110:5)
    at getRawBody (node_modules/raw-body/index.js:109:10)
    at poster (/index.js:5:15)
    at node_modules/microrouter/lib/index.js:13:14
    at funcs.map.fn (node_modules/microrouter/lib/index.js:19:19)
    at Array.map (native)
    at node_modules/microrouter/lib/index.js:19:9
    at Function.exports.run (node_modules/micro/lib/server.js:24:11)
    at Server.server (node_modules/micro/lib/server.js:15:50)
    at emitTwo (events.js:106:13)
    at Server.emit (events.js:194:7)
    at parserOnIncoming (_http_server.js:565:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:99:23)

```

I had trouble adding a test for this. `micro.json()` seemed to just be hanging within the test. Maybe you have better luck?

Did cloning `req` serve any purpose?