### PR TITLE
Fixed README notfound route

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const { router, get } = require('microrouter')
 const hello = (req, res) =>
   send(res, 200, `Hello ${req.params.who}`)
 
-const notfound = () =>
+const notfound = (req, res) =>
   send(res, 404, 'Not found route')
 
 module.exports = router(


### PR DESCRIPTION
The notfound route included in the readme fails due to `res` not being defined. This PR fixes the docs to include req and res in the not found handler args.