### PR TITLE
Multiple matching routes called

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,12 @@ const methodFn = method => (path, handler) => {
   }
 }
 
-exports.router = (...funcs) => async (req, res) =>
-  funcs.map(fn => fn(req, res)).find(fn => fn)
+exports.router = (...funcs) => async (req, res) => {
+  for (const fn of funcs) {
+    const result = await fn(req, res)
+    if (result) return result
+  }
+}
 
 METHODS.forEach(method => {
   exports[method.toLowerCase()] = methodFn(method)

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const methodFn = method => (path, handler) => {
 exports.router = (...funcs) => async (req, res) => {
   for (const fn of funcs) {
     const result = await fn(req, res)
-    if (result) return result
+    if (result || res.headersSent) return result
   }
 }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -65,6 +65,21 @@ test('not found route', async t => {
   t.is(notfoundResponse, 'Not found')
 })
 
+test('multiple matching routes', async t => {
+  const withPath = () => 'Hello world'
+  const withParam = () => t.fail('Clashing route should not have been called')
+
+  const routes = router(
+    get('/path', withPath),
+    get('/:param', withParam)
+  )
+
+  const url = await server(routes)
+  const pathResponse = await request(`${url}/path`)
+
+  t.is(pathResponse, 'Hello world')
+})
+
 test('error without path and handler', async t => {
   const fn = () => {
     router(get())

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -80,6 +80,21 @@ test('multiple matching routes', async t => {
   t.is(pathResponse, 'Hello world')
 })
 
+test('multiple matching async routes', async t => {
+  const withPath = (req, res) => micro.send(res, 200, 'Hello world')
+  const withParam = () => t.fail('Clashing route should not have been called')
+
+  const routes = router(
+    get('/path', withPath),
+    get('/:param', withParam)
+  )
+
+  const url = await server(routes)
+  const pathResponse = await request(`${url}/path`)
+
+  t.is(pathResponse, 'Hello world')
+})
+
 test('error without path and handler', async t => {
   const fn = () => {
     router(get())

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "rules": {
       "curly": 0,
       "object-curly-spacing": 0,
-      "unicorn/explicit-length-check": 0
+      "unicorn/explicit-length-check": 0,
+      "no-await-in-loop": 0
     }
   },
   "engines": {


### PR DESCRIPTION
I had an issue where two routes were matching for the same request, as reproduced in the tests I added.

I changed it so that instead of calling all matching route handlers in parallel, it now calls them serially until it finds one that is valid.