### PR TITLE
Avoid rebuilding UrlPattern instances

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+const UrlPattern = require('url-pattern')
 const { getParamsAndQuery } = require('../utils')
 
 const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
@@ -6,8 +7,10 @@ const methodFn = method => (path, handler) => {
   if (!path) throw new Error('You need to set a valid path')
   if (!handler) throw new Error('You need to set a valid handler')
 
+  const route = new UrlPattern(path)
+
   return (req, res) => {
-    const { params, query } = getParamsAndQuery(path, req.url)
+    const { params, query } = getParamsAndQuery(route, req.url)
 
     if (params && req.method === method) {
       return handler(Object.assign(req, { params, query }), res)

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,11 +1,13 @@
 const { parse } = require('url')
 const UrlPattern = require('url-pattern')
 
-const getParamsAndQuery = (pattern, url) => {
+const getParamsAndQuery = (patternOrRoute, url) => {
   const { query, pathname } = parse(url, true)
-  const route = new UrlPattern(pattern)
-  const params = route.match(pathname)
 
+  const route =
+    patternOrRoute instanceof UrlPattern ? patternOrRoute : new UrlPattern(patternOrRoute)
+
+  const params = route.match(pathname)
   return { query, params }
 }
 

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+const UrlPattern = require('url-pattern')
 
 const { getParamsAndQuery } = require('./')
 
@@ -7,6 +8,16 @@ test('getParamsAndQuery()', t => {
   const url = '/hello/world?id=0'
 
   const { params, query } = getParamsAndQuery(path, url)
+
+  t.deepEqual(params, { msg: 'world' })
+  t.deepEqual(query, { id: '0' })
+})
+
+test('getParamsAndQuery() with UrlPattern', t => {
+  const route = new UrlPattern('/hello/:msg')
+  const url = '/hello/world?id=0'
+
+  const { params, query } = getParamsAndQuery(route, url)
 
   t.deepEqual(params, { msg: 'world' })
   t.deepEqual(query, { id: '0' })


### PR DESCRIPTION
Small efficiency tweak, keeps the current API intact as well in case anyone is importing `microrouter/util` directly.