### PR TITLE
feat: Default 404 handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,9 @@ exports.router = (...funcs) => async (req, res) => {
     const result = await fn(req, res)
     if (result || res.headersSent) return result
   }
+
+  res.writeHead(404)
+  res.end(`Cannot ${req.method} ${req.url}`)
 }
 
 METHODS.forEach(method => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const UrlPattern = require('url-pattern')
+const { send } = require('micro')
 const { getParamsAndQuery } = require('../utils')
 
 const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
@@ -24,8 +25,7 @@ exports.router = (...funcs) => async (req, res) => {
     if (result || res.headersSent) return result
   }
 
-  res.writeHead(404)
-  res.end(`Cannot ${req.method} ${req.url}`)
+  send(res, 404, `Cannot ${req.method} ${req.url}`)
 }
 
 METHODS.forEach(method => {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -48,7 +48,26 @@ test('async handlers', async t => {
   t.is(response, 'Hello world now')
 })
 
-test('not found route', async t => {
+test('default 404 handler', async t => {
+  const hello = () => 'Hello world'
+
+  const routes = router(
+    get('/hello', hello)
+  )
+
+  const url = await server(routes)
+  const helloResponse = await request(`${url}/hello`)
+  t.is(helloResponse, 'Hello world')
+
+  const notfoundResponse = await request(`${url}/api`, {
+    simple: false,
+    resolveWithFullResponse: true
+  })
+  t.is(notfoundResponse.statusCode, 404)
+  t.is(notfoundResponse.body, 'Cannot GET /api')
+})
+
+test('custom 404 handler', async t => {
   const hello = () => 'Hello world'
   const notfound = () => 'Not found'
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Pedro Nauck <pedronauck@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "micro": "^7.3.3",
     "url-pattern": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
If no route was found, then reply with a 404. The text in the body is inspired by express.

Fixes #18 