### PR TITLE
Add tests for streams in route handler responses

### DIFF
--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,3 +1,5 @@
+const { Readable } = require('stream')
+const fs = require('fs')
 const test = require('ava')
 const micro = require('micro')
 const listen = require('test-listen')
@@ -7,7 +9,7 @@ const { router, get } = require('./')
 
 const server = fn => listen(micro(fn))
 
-test('diferent routes', async t => {
+test('different routes', async t => {
   const routes = router(
     get('/foo', () => ({ name: 'foo' })),
     get('/bar', () => ({ name: 'bar' }))
@@ -127,4 +129,35 @@ test('error without handler', t => {
 
   const error = t.throws(fn, Error)
   t.is(error.message, 'You need to set a valid handler')
+})
+
+test('route which sends a Stream', async t => {
+  const stream = new Readable()
+  stream._read = () => {} // Noop
+  stream.push('foo')
+  stream.push(null) // End
+
+  const routes = router(
+    get('/', (req, res) => micro.send(res, 200, stream))
+  )
+
+  const url = await server(routes)
+  const response = await request(url)
+
+  t.is(response, 'foo')
+})
+
+test('route which sends a file stream', async t => {
+  const stream = fs.createReadStream('./package.json')
+
+  const routes = router(
+    get('/', (req, res) => micro.send(res, 200, stream))
+  )
+
+  const url = await server(routes)
+  const response = await request(url)
+
+  const json = JSON.parse(response)
+
+  t.is(json.name, 'microrouter')
 })


### PR DESCRIPTION
This patch adds two tests cases for sending a stream to `micro.send` from within a route handler. Tried to reproduce https://github.com/pedronauck/micro-router/issues/32.