### PR TITLE
Move `micro` to the `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Pedro Nauck <pedronauck@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "micro": "^9.0.0",
     "url-pattern": "^1.0.3"
   },
   "devDependencies": {
@@ -21,7 +22,6 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "coveralls": "^3.0.0",
-    "micro": "^9.0.0",
     "np": "^2.16.0",
     "nyc": "^11.2.1",
     "request": "^2.83.0",


### PR DESCRIPTION
Since `micro` is used at https://github.com/pedronauck/micro-router/blob/7779f333ad2034243711ba22d70966dad1f6a1f3/lib/index.js#L2, it should be listed in `dependencies` instead of `devDependencies` to avoid errors when installing packages.