### PR TITLE
fix: made trailing slash optional for namespaced routes

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,9 +8,12 @@ const methodFn = method => (path, handler) => {
   if (!handler) throw new Error('You need to set a valid handler')
 
   return (req, res, namespace) => {
-    const route = !isPattern(path)
-      ? new UrlPattern(`${namespace}${path}`, patternOpts)
-      : path
+    if (path === '/') {
+      path = '(/)'
+    }
+    const route = isPattern(path)
+      ? path
+      : new UrlPattern(`${namespace}${path}`, patternOpts)
 
     const { params, query } = getParamsAndQuery(route, req.url)
 

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -177,3 +177,25 @@ test('routes with namespace', async t => {
   t.is(fooResponse, 'foo')
   t.is(barResponse, 'bar')
 })
+
+test('route with namespace without trailing slash', async t => {
+  const fooRoutes = withNamespace('/foo')
+
+  const routes = router(fooRoutes(get('/', () => 'foo')))
+
+  const url = await server(routes)
+  const fooResponse = await request(`${url}/foo`)
+
+  t.is(fooResponse, 'foo')
+})
+
+test('route with namespace with trailing slash', async t => {
+  const fooRoutes = withNamespace('/foo')
+
+  const routes = router(fooRoutes(get('/', () => 'foo')))
+
+  const url = await server(routes)
+  const fooResponse = await request(`${url}/foo/`)
+
+  t.is(fooResponse, 'foo')
+})


### PR DESCRIPTION
When using `withNamespace()`, requesting the "index" route of the namespace requires a trailing slash to match. The namespace example at the bottom of the **readme** does not work without appending a trailing slash to the url.

**Example code**:

```javascript
const apiRoute = withNamespace('/api')

const routes = router(
  apiRoute(get('/', () => 'My api route'))
)

// Start server...

request(`${SERVER_URL}/api`)  <-- Does NOT work
request(`${SERVER_URL}/api/`) <-- Works
```

This PR makes the trailing slash optional for namespaced routes (in par with non-namespaced index routes). **Note**: It does _not_ make trailing slashes optional for all routes, only for index routes. 