### PR TITLE
Add support for extra attributes in route handlers

### DIFF
--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -9,22 +9,22 @@ const methodFn = method => (givenPath, handler) => {
   if (!givenPath) throw new Error('You need to set a valid path');
   if (!handler) throw new Error('You need to set a valid handler');
 
-  return (req, res, namespace) => {
+  return (req, res, namespace, ...args) => {
     const path = givenPath === '/' ? '(/)' : givenPath;
     const route = isPattern(path) ? path : new UrlPattern(`${namespace}${path}`, patternOpts);
 
     const { params, query } = getParamsAndQuery(route, req.url);
 
     if (params && req.method === method) {
-      return handler(Object.assign(req, { params, query }), res);
+      return handler(Object.assign(req, { params, query }), res, ...args);
     }
   };
 };
 
 const findRoute = (funcs, namespace = '') => (() => {
-  var _ref = _asyncToGenerator(function* (req, res) {
+  var _ref = _asyncToGenerator(function* (req, res, ...args) {
     for (const fn of funcs) {
-      const result = yield fn(req, res, namespace);
+      const result = yield fn(req, res, namespace, ...args);
       if (result || res.headersSent) return result;
     }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,7 +7,7 @@ const methodFn = method => (givenPath, handler) => {
   if (!givenPath) throw new Error('You need to set a valid path')
   if (!handler) throw new Error('You need to set a valid handler')
 
-  return (req, res, namespace) => {
+  return (req, res, namespace, ...args) => {
     const path = givenPath === '/' ? '(/)' : givenPath
     const route = isPattern(path)
       ? path
@@ -16,14 +16,14 @@ const methodFn = method => (givenPath, handler) => {
     const { params, query } = getParamsAndQuery(route, req.url)
 
     if (params && req.method === method) {
-      return handler(Object.assign(req, { params, query }), res)
+      return handler(Object.assign(req, { params, query }), res, ...args)
     }
   }
 }
 
-const findRoute = (funcs, namespace = '') => async (req, res) => {
+const findRoute = (funcs, namespace = '') => async (req, res, ...args) => {
   for (const fn of funcs) {
-    const result = await fn(req, res, namespace)
+    const result = await fn(req, res, namespace, ...args)
     if (result || res.headersSent) return result
   }
 

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -199,3 +199,15 @@ test('route with namespace with trailing slash', async t => {
 
   t.is(fooResponse, 'foo')
 })
+
+test('route with extra arguments', async t => {
+  const serverWithSetup = fn =>
+    listen(micro((req, res) => fn(req, res, 'extra')))
+
+  const routes = router(get('/', (req, res, message) => ({ message })))
+
+  const url = await serverWithSetup(routes)
+  const response = await request(`${url}`)
+
+  t.is(JSON.parse(response).message, 'extra')
+})


### PR DESCRIPTION
Hello.

This makes it possible to use extra arguments like `database` in the next example: https://github.com/zeit/micro/pull/335
