### PR TITLE
ISSUE-57 | Fix url-pattern allowed values

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -2,8 +2,8 @@ const { parse } = require('url');
 const UrlPattern = require('url-pattern');
 
 const patternOpts = {
-  segmentNameCharset: 'a-zA-Z0-9_-',
-  segmentValueCharset: 'a-zA-Z0-9@.+-_'
+  segmentNameCharset: 'a-zA-Z0-9_\\-',
+  segmentValueCharset: 'a-zA-Z0-9@.+\\-_'
 };
 
 const isPattern = pattern => pattern instanceof UrlPattern;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,8 +2,8 @@ const { parse } = require('url')
 const UrlPattern = require('url-pattern')
 
 const patternOpts = {
-  segmentNameCharset: 'a-zA-Z0-9_-',
-  segmentValueCharset: 'a-zA-Z0-9@.+-_',
+  segmentNameCharset: 'a-zA-Z0-9_\\-',
+  segmentValueCharset: 'a-zA-Z0-9@.+\\-_',
 }
 
 const isPattern = pattern => pattern instanceof UrlPattern


### PR DESCRIPTION
Related issue https://github.com/pedronauck/micro-router/issues/57
Regexp with `a-zA-Z0-9@.+-_` matches a lot of unnecessary characters.
The problem is that `-` in `+-_` is a special character and it matches all characters between `+`(43) and `_`(95).