### PR TITLE
[New Feature] routerNamespace ( nested Namespaces )

### DIFF
--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -37,8 +37,27 @@ const findRoute = (funcs, namespace = '') => (() => {
 })();
 
 exports.router = (...funcs) => findRoute(funcs);
-exports.withNamespace = namespace => (...funcs) => findRoute(funcs, namespace);
+
+const withNamespace = namespace => (...funcs) => findRoute(funcs, namespace);
+exports.withNamespace = withNamespace;
 
 METHODS.forEach(method => {
   exports[method === 'DELETE' ? 'del' : method.toLowerCase()] = methodFn(method);
 });
+
+exports.routerNamespace = (...handlers) => upperNameSpace => {
+  return (() => {
+    var _ref2 = _asyncToGenerator(function* (req, res, ns) {
+      const namespacePrefix = `${ns}${upperNameSpace}(/)(/:any)`;
+      const namespace = `${ns}${upperNameSpace}`;
+      const { params } = getParamsAndQuery(namespacePrefix, req.url);
+      if (params) {
+        return withNamespace(namespace)(...handlers)(req, res);
+      }
+    });
+
+    return function (_x3, _x4, _x5) {
+      return _ref2.apply(this, arguments);
+    };
+  })();
+};

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -31,8 +31,21 @@ const findRoute = (funcs, namespace = '') => async (req, res) => {
 }
 
 exports.router = (...funcs) => findRoute(funcs)
-exports.withNamespace = namespace => (...funcs) => findRoute(funcs, namespace)
+
+const withNamespace = namespace => (...funcs) => findRoute(funcs, namespace)
+exports.withNamespace = withNamespace
 
 METHODS.forEach(method => {
   exports[method === 'DELETE' ? 'del' : method.toLowerCase()] = methodFn(method)
 })
+
+exports.routerNamespace = (...handlers) => upperNameSpace => {
+  return async (req, res, ns) => {
+    const namespacePrefix = `${ns}${upperNameSpace}(/)(/:any)`
+    const namespace = `${ns}${upperNameSpace}`
+    const { params } = getParamsAndQuery(namespacePrefix, req.url)
+    if (params) {
+      return withNamespace(namespace)(...handlers)(req, res)
+    }
+  }
+}

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -154,7 +154,7 @@ test('allow handlers returning null', async t => {
   const url = await server(routes)
   const reponse = await request(`${url}/null`, {
     simple: false,
-    resolveWithFullResponse: true
+    resolveWithFullResponse: true,
   })
 
   t.not(reponse.statusCode, 404)
@@ -203,23 +203,15 @@ test('route with namespace with trailing slash', async t => {
 test('route under routerNamespace can be used under withNamespace', async t => {
   const fooRoutes = withNamespace('/foo')
 
-  const final = routerNamespace(
-    get('/', () => 'final')
-  )
-  const innerBar = routerNamespace(
-    get('/', () => 'inner bar'),
-    final('/final')
-  )
+  const final = routerNamespace(get('/', () => 'final'))
+  const innerBar = routerNamespace(get('/', () => 'inner bar'), final('/final'))
 
   const innerFoo = routerNamespace(
     get('/', () => 'inner foo'),
     innerBar('/bar')
   )
 
-  const routes = router(fooRoutes(
-    get('/', () => 'foo'),
-    innerFoo('/bar')
-  ))
+  const routes = router(fooRoutes(get('/', () => 'foo'), innerFoo('/bar')))
 
   const url = await server(routes)
   const fooResponse = await request(`${url}/foo/`)

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -6,7 +6,7 @@ const listen = require('test-listen')
 const request = require('request-promise')
 const UrlPattern = require('url-pattern')
 
-const { withNamespace, router, get } = require('./')
+const { withNamespace, router, get, routerNamespace } = require('./')
 
 const server = fn => listen(micro(fn))
 
@@ -154,7 +154,7 @@ test('allow handlers returning null', async t => {
   const url = await server(routes)
   const reponse = await request(`${url}/null`, {
     simple: false,
-    resolveWithFullResponse: true,
+    resolveWithFullResponse: true
   })
 
   t.not(reponse.statusCode, 404)
@@ -198,4 +198,39 @@ test('route with namespace with trailing slash', async t => {
   const fooResponse = await request(`${url}/foo/`)
 
   t.is(fooResponse, 'foo')
+})
+
+test('route under routerNamespace can be used under withNamespace', async t => {
+  const fooRoutes = withNamespace('/foo')
+
+  const final = routerNamespace(
+    get('/', () => 'final')
+  )
+  const innerBar = routerNamespace(
+    get('/', () => 'inner bar'),
+    final('/final')
+  )
+
+  const innerFoo = routerNamespace(
+    get('/', () => 'inner foo'),
+    innerBar('/bar')
+  )
+
+  const routes = router(fooRoutes(
+    get('/', () => 'foo'),
+    innerFoo('/bar')
+  ))
+
+  const url = await server(routes)
+  const fooResponse = await request(`${url}/foo/`)
+  t.is(fooResponse, 'foo')
+
+  const innerFooResponse = await request(`${url}/foo/bar`)
+  t.is(innerFooResponse, 'inner foo')
+
+  const innerBarResponse = await request(`${url}/foo/bar/bar`)
+  t.is(innerBarResponse, 'inner bar')
+
+  const finalResponse = await request(`${url}/foo/bar/bar/final`)
+  t.is(finalResponse, 'final')
 })

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -203,7 +203,10 @@ test('route with namespace with trailing slash', async t => {
 test('route under routerNamespace can be used under withNamespace', async t => {
   const fooRoutes = withNamespace('/foo')
 
-  const final = routerNamespace(get('/', () => 'final'))
+  const final = routerNamespace(
+    get('/:id', req => req.params.id),
+    get('/', () => 'final')
+  )
   const innerBar = routerNamespace(get('/', () => 'inner bar'), final('/final'))
 
   const innerFoo = routerNamespace(
@@ -225,4 +228,7 @@ test('route under routerNamespace can be used under withNamespace', async t => {
 
   const finalResponse = await request(`${url}/foo/bar/bar/final`)
   t.is(finalResponse, 'final')
+
+  const finalParamResponse = await request(`${url}/foo/bar/bar/final/123`)
+  t.is(finalParamResponse, '123')
 })


### PR DESCRIPTION
This pull request is to enable creating namespace routes as nested to another namespace route.
`GET /foo/bar/bar` would return `'inner bar'`
```
  const fooRoutes = withNamespace('/foo')
  const innerBar = routerNamespace(
     get('/', () => 'inner bar')
   )

  const innerFoo = routerNamespace(
    get('/', () => 'inner foo'),
    innerBar('/bar')
  )

  const routes = router(
    fooRoutes(
        get('/', () => 'foo'), 
         innerFoo('/bar')
     )
  )
```